### PR TITLE
Fix: InstallMsi fails when $Path contains apostrophe

### DIFF
--- a/functions/private.ps1
+++ b/functions/private.ps1
@@ -52,20 +52,22 @@ Function InstallMsi {
         [string]$Mode = "Full"
     )
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Creating install command for $Path"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Creating Start-Process parameters"
 
-    switch ($Mode) {
-        "Full" { $installParam = "/qf" }
-        "Quiet" { $installparam = "/quiet"}
-        "Passive" {$installParam = "/passive"}
+    $installParams = @{
+        "FilePath"     = $Path
+        "ArgumentList" = switch ($Mode) {
+            "Full"    {"/qf" }
+            "Quiet"   {"/quiet"}
+            "Passive" {"/passive"}
+        }
     }
-    $cmd = "Start-Process -filepath '$Path' -argumentlist '$installParam'"
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] $cmd"
-    $sb = [scriptblock]::Create($cmd)
+    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] FilePath: $($installParams.FilePath)"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] ArgumentList: $($installParams.ArgumentList)"
 
-    if ($pscmdlet.ShouldProcess($sb)) {
-        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Invoking command"
-        Invoke-Command -scriptblock $sb
+    if ($pscmdlet.ShouldProcess("$($installParams.FilePath) $($installParams.ArgumentList)")) {
+        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Starting process"
+        Start-Process @installParams 
     }
 
     Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Ending function"


### PR DESCRIPTION
The bug is that the InstallMSI function fails when the invoking user's username contains an apostrophe.

I hope this patch fixes the problem.

I'm now executing the MSI with Start-Process directly rather than via Invoke-Command and a string.

I've tried to match the coding style used elsewhere, and to preserve the level of detail in -Verbose and -WhatIf modes.

Pester tests all still pass.

This is my first Pull Request, and I'm very happy to get feedback either on the PowerShell or Git side of things.

Cheers!
