### PR TITLE
Fix casing and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Install-Module PSReleaseTools
 On PowerShell you might need to run:
 
 ```powershell
-Install-Module PSReleaseTools [-scope currentuser]
+Install-Module PSReleaseTools [-Scope CurrentUser]
 ```
 
 ## Support

--- a/Tests/PSReleaseTools.tests.ps1
+++ b/Tests/PSReleaseTools.tests.ps1
@@ -3,12 +3,12 @@ Remove-Module PSReleaseTools -ErrorAction SilentlyContinue
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $modRoot = Split-Path -Parent $here | Convert-Path
 
-Write-Host "Importing module from $script:modroot" -ForegroundColor magenta
+Write-Host "Importing module from $script:modroot" -ForegroundColor Magenta
 Import-Module $modRoot -Force
 
 InModuleScope PSReleaseTools {
 
-    $modPath = Get-Module psreleasetools | Select-Object path | Split-Path
+    $modPath = Get-Module PSReleaseTools | Select-Object path | Split-Path
     Describe PSReleaseTools {
         It "Has exported commands" {
             {Get-Command -Module PSReleaseTools} | Should -Be $true
@@ -21,15 +21,15 @@ InModuleScope PSReleaseTools {
         Context Manifest {
 
             It "Has a manifest" {
-                Get-Item -Path $modpath\PSReleaseTools.psd1 | Should -Be $True
+                Get-Item -Path $modpath\PSReleaseTools.psd1 | Should -Be $true
             }
 
             It "Has a license URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["LicenseUri"] | Should -Be $True
+                (Get-Module PSReleaseTools).PrivateData["PSData"]["LicenseUri"] | Should -Be $true
             }
 
             It "Has a project URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["ProjectUri"] | Should -Be $True
+                (Get-Module PSReleaseTools).PrivateData["PSData"]["ProjectUri"] | Should -Be $true
             }
         } #context
     }
@@ -56,15 +56,15 @@ InModuleScope PSReleaseTools {
         }
 
         It "Result should have a Filename property" {
-            ($script:dl)[0].Filename | Should -Be $True
+            ($script:dl)[0].Filename | Should -Be $true
         }
 
         It "Result should have an URL property with https" {
-            ($Script:dl)[0].url | Should -Match "^https"
+            ($Script:dl)[0].URL | Should -Match "^https"
         }
 
         It "Result should have an [int] SizeMB property" {
-            ($script:dl)[0].sizeMB | Should -BeOfType "System.Int32"
+            ($script:dl)[0].SizeMB | Should -BeOfType "System.Int32"
         }
     }
 
@@ -73,24 +73,24 @@ InModuleScope PSReleaseTools {
             {$script:sum = Get-PSReleaseSummary -ErrorAction Stop} | Should -Not -Throw
         }
         It "Writes a string to the pipeline" {
-            $script:sum.getType().Name | Should -Be "string"
+            $script:sum.GetType().Name | Should -Be "string"
         }
     }
 
     Describe Save-PSReleaseAsset {
         It "Has no tests defined at this time." {
-            $true | Should -Be $True
+            $true | Should -Be $true
         }
     }
     Describe Install-PSPreview {
         It "Has no tests defined at this time." {
-            $true | Should -Be $True
+            $true | Should -Be $true
         }
     }
 
     Describe Install-PSCore {
         It "Has no tests defined at this time." {
-            $true | Should -Be $True
+            $true | Should -Be $true
         }
     }
 }

--- a/Tests/PSReleaseTools.tests.ps1
+++ b/Tests/PSReleaseTools.tests.ps1
@@ -15,7 +15,7 @@ InModuleScope PSReleaseTools {
         }
 
         It "Has a README.md file" {
-            $f = Get-Item -Path $(Join-path -path $modpath -childpath README.md)
+            $f = Get-Item -Path $(Join-Path -Path $modpath -ChildPath README.md)
             $f.name | Should -Be "readme.md"
         }
         Context Manifest {
@@ -25,11 +25,11 @@ InModuleScope PSReleaseTools {
             }
 
             It "Has a license URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["LicenseUri"] | Should -be $True
+                (Get-Module psreleasetools).PrivateData["PSData"]["LicenseUri"] | Should -Be $True
             }
 
             It "Has a project URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["ProjectUri"] | Should -be $True
+                (Get-Module psreleasetools).PrivateData["PSData"]["ProjectUri"] | Should -Be $True
             }
         } #context
     }
@@ -39,7 +39,7 @@ InModuleScope PSReleaseTools {
             {$script:data = Get-PSReleaseAsset -ErrorAction Stop} | Should -Not -Throw
         }
         It "Writes one or more objects to the pipeline" {
-            $script:data.count | Should -beGreaterThan 1
+            $script:data.count | Should -BeGreaterThan 1
         }
 
         $FamilyValues = (Get-Command Get-PSReleaseAsset).Parameters["Family"].Attributes.ValidValues
@@ -52,7 +52,7 @@ InModuleScope PSReleaseTools {
         }
         It "Should get release assets for Ubuntu" {
             $script:dl = Get-PSReleaseAsset -Family Ubuntu
-            ($script:dl).Count | Should -beGreaterThan 0
+            ($script:dl).Count | Should -BeGreaterThan 0
         }
 
         It "Result should have a Filename property" {
@@ -79,18 +79,18 @@ InModuleScope PSReleaseTools {
 
     Describe Save-PSReleaseAsset {
         It "Has no tests defined at this time." {
-            $true | should -be $True
+            $true | Should -Be $True
         }
     }
     Describe Install-PSPreview {
         It "Has no tests defined at this time." {
-            $true | should -be $True
+            $true | Should -Be $True
         }
     }
 
     Describe Install-PSCore {
         It "Has no tests defined at this time." {
-            $true | should -be $True
+            $true | Should -Be $True
         }
     }
 }

--- a/Tests/PSReleaseTools.tests.ps1
+++ b/Tests/PSReleaseTools.tests.ps1
@@ -11,86 +11,86 @@ InModuleScope PSReleaseTools {
     $modPath = Get-Module psreleasetools | Select-Object path | Split-Path
     Describe PSReleaseTools {
         It "Has exported commands" {
-            {Get-Command -Module PSReleaseTools} | Should Be $true
+            {Get-Command -Module PSReleaseTools} | Should -Be $true
         }
 
         It "Has a README.md file" {
             $f = Get-Item -Path $(Join-path -path $modpath -childpath README.md)
-            $f.name | Should Be "readme.md"
+            $f.name | Should -Be "readme.md"
         }
         Context Manifest {
 
             It "Has a manifest" {
-                Get-Item -Path $modpath\PSReleaseTools.psd1 | Should Be $True
+                Get-Item -Path $modpath\PSReleaseTools.psd1 | Should -Be $True
             }
 
             It "Has a license URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["LicenseUri"] | Should be $True
+                (Get-Module psreleasetools).PrivateData["PSData"]["LicenseUri"] | Should -be $True
             }
 
             It "Has a project URI" {
-                (Get-Module psreleasetools).PrivateData["PSData"]["ProjectUri"] | Should be $True
+                (Get-Module psreleasetools).PrivateData["PSData"]["ProjectUri"] | Should -be $True
             }
         } #context
     }
 
     Describe Get-PSReleaseAsset {
         It "Runs without error" {
-            {$script:data = Get-PSReleaseAsset -ErrorAction Stop} | Should Not Throw
+            {$script:data = Get-PSReleaseAsset -ErrorAction Stop} | Should -Not -Throw
         }
         It "Writes one or more objects to the pipeline" {
-            $script:data.count | Should beGreaterThan 1
+            $script:data.count | Should -beGreaterThan 1
         }
 
         $FamilyValues = (Get-Command Get-PSReleaseAsset).Parameters["Family"].Attributes.ValidValues
         It "Has a validation set for Family" {
-            $FamilyValues.count | Should Be 12
+            $FamilyValues.count | Should -Be 12
         }
 
         It "Should fail with a bad Family value" {
-            {Get-PSReleaseAsset -Family FOO -ErrorAction} | Should Throw
+            {Get-PSReleaseAsset -Family FOO -ErrorAction} | Should -Throw
         }
         It "Should get release assets for Ubuntu" {
             $script:dl = Get-PSReleaseAsset -Family Ubuntu
-            ($script:dl).Count | Should beGreaterThan 0
+            ($script:dl).Count | Should -beGreaterThan 0
         }
 
         It "Result should have a Filename property" {
-            ($script:dl)[0].Filename | Should Be $True
+            ($script:dl)[0].Filename | Should -Be $True
         }
 
         It "Result should have an URL property with https" {
-            ($Script:dl)[0].url | Should Match "^https"
+            ($Script:dl)[0].url | Should -Match "^https"
         }
 
         It "Result should have an [int] SizeMB property" {
-            ($script:dl)[0].sizeMB | Should BeOfType "System.Int32"
+            ($script:dl)[0].sizeMB | Should -BeOfType "System.Int32"
         }
     }
 
     Describe Get-PSReleaseSummary {
         It "Runs without error" {
-            {$script:sum = Get-PSReleaseSummary -ErrorAction Stop} | Should Not Throw
+            {$script:sum = Get-PSReleaseSummary -ErrorAction Stop} | Should -Not -Throw
         }
         It "Writes a string to the pipeline" {
-            $script:sum.getType().Name | Should Be "string"
+            $script:sum.getType().Name | Should -Be "string"
         }
     }
 
     Describe Save-PSReleaseAsset {
         It "Has no tests defined at this time." {
-            $true | should be $True
+            $true | should -be $True
         }
     }
     Describe Install-PSPreview {
         It "Has no tests defined at this time." {
-            $true | should be $True
+            $true | should -be $True
         }
     }
 
     Describe Install-PSCore {
         It "Has no tests defined at this time." {
-            $true | should be $True
+            $true | should -be $True
         }
     }
 }

--- a/functions/private.ps1
+++ b/functions/private.ps1
@@ -1,50 +1,50 @@
 #these are internal functions for the PSReleaseTools module
 
 #define an internal function to download the file
-Function DL {
-    [cmdletbinding(SupportsShouldProcess)]
-    Param([string]$Source, [string]$Destination, [string]$hash, [switch]$Passthru)
+function DL {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Source, [string]$Destination, [string]$Hash, [switch]$Passthru)
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] $Source to $Destination"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] $Source to $Destination"
 
-    if ($pscmdlet.ShouldProcess($Destination, "Downloading $source")) {
+    if ($PSCmdlet.ShouldProcess($Destination, "Downloading $Source")) {
         Invoke-WebRequest -Uri $source -UseBasicParsing -DisableKeepAlive -OutFile $Destination
-        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Comparing file hash to $hash"
+        Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Comparing file hash to $Hash"
         $f = Get-FileHash -Path $Destination -Algorithm SHA256
-        if ($f.hash -ne $hash) {
+        if ($f.Hash -ne $Hash) {
             Write-Warning "Hash mismatch. $Destination may be incomplete."
         }
 
-        if ($passthru) {
+        if ($Passthru) {
             Get-Item $Destination
         }
     } #should process
 } #DL
 
-Function GetData {
-    [cmdletbinding()]
-    Param(
+function GetData {
+    [CmdletBinding()]
+    param(
         [switch]$Preview
     )
 
     $uri = "https://api.github.com/repos/powershell/powershell/releases"
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting current release information from $uri"
-    $get = Invoke-RestMethod -Uri $uri -Method Get -ErrorAction stop
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Getting current release information from $uri"
+    $get = Invoke-RestMethod -Uri $uri -Method Get -ErrorAction Stop
 
     if ($Preview) {
-        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting latest preview"
+        Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Getting latest preview"
         ($get).where( {$_.prerelease}) | Select-Object -First 1
     }
     else {
-        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting latest stable release"
+        Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Getting latest stable release"
         ($get).where( { -NOT $_.prerelease}) | Select-Object -First 1
     }
 }
 
-Function InstallMsi {
-    [cmdletbinding(SupportsShouldProcess)]
-    Param(
+function InstallMsi {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
         [Parameter(Mandatory, HelpMessage = "The full path to the MSI file")]
         [ValidateScript({Test-Path $_})]
         [string]$Path,
@@ -57,7 +57,7 @@ Function InstallMsi {
         [switch]$EnableContextMenu
     )
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Creating Start-Process parameters"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Creating Start-Process parameters"
 
     $modeOption = switch ($Mode) {
         "Full"    {"/qf" }
@@ -74,14 +74,14 @@ Function InstallMsi {
         $installOption += " ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"
     }
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] FilePath: $Path"
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] ArgumentList: $installOption"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] FilePath: $Path"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] ArgumentList: $installOption"
 
-    if ($pscmdlet.ShouldProcess("$Path $installOption")) {
-        Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Starting installation process"
+    if ($PSCmdlet.ShouldProcess("$Path $installOption")) {
+        Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Starting installation process"
         Start-Process -FilePath $Path -ArgumentList $installOption
     }
 
-    Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Ending function"
+    Write-Verbose "[$((Get-Date).TimeofDay) $($MyInvocation.MyCommand)] Ending function"
 
 } #close installmsi

--- a/functions/private.ps1
+++ b/functions/private.ps1
@@ -8,7 +8,7 @@ Function DL {
     Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] $Source to $Destination"
 
     if ($pscmdlet.ShouldProcess($Destination, "Downloading $source")) {
-        Invoke-Webrequest -Uri $source -UseBasicParsing -DisableKeepAlive -OutFile $Destination
+        Invoke-WebRequest -Uri $source -UseBasicParsing -DisableKeepAlive -OutFile $Destination
         Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Comparing file hash to $hash"
         $f = Get-FileHash -Path $Destination -Algorithm SHA256
         if ($f.hash -ne $hash) {
@@ -30,15 +30,15 @@ Function GetData {
     $uri = "https://api.github.com/repos/powershell/powershell/releases"
 
     Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting current release information from $uri"
-    $get = Invoke-Restmethod -uri $uri -Method Get -ErrorAction stop
+    $get = Invoke-RestMethod -Uri $uri -Method Get -ErrorAction stop
 
     if ($Preview) {
         Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting latest preview"
-        ($get).where( {$_.prerelease}) | Select-Object -first 1
+        ($get).where( {$_.prerelease}) | Select-Object -First 1
     }
     else {
         Write-Verbose "[$((Get-Date).TimeofDay) $($myinvocation.mycommand)] Getting latest stable release"
-        ($get).where( { -NOT $_.prerelease}) | Select-Object -first 1
+        ($get).where( { -NOT $_.prerelease}) | Select-Object -First 1
     }
 }
 

--- a/functions/public.ps1
+++ b/functions/public.ps1
@@ -105,7 +105,7 @@ Function Get-PSReleaseSummary {
             if ($AsMarkdown) {
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Formatting as markdown"
                 #create a markdown table from download data
-                $tbl = (($DL | ConvertTo-Csv -notypeInformation -delimiter "|").Replace('"', '') -Replace '^', "|") -replace "$", "|`n"
+                $tbl = (($DL | ConvertTo-Csv -NoTypeInformation -Delimiter "|").Replace('"', '') -Replace '^', "|") -replace "$", "|`n"
 
                 $out = @"
 # $($data.Name.trim())
@@ -308,7 +308,7 @@ Function Get-PSReleaseAsset {
             $r = $rx.Matches($data.body)
             $r | ForEach-Object -Begin {
                 $h = @{}
-            } -process {
+            } -Process {
                 #if there is a duplicate entry, assume it is part of a Note
                 $f = $_.groups["file"].value.trim()
                 $v = $_.groups["hash"].value.trim()
@@ -425,7 +425,7 @@ Function Install-PSPreview {
             if ($PSBoundParameters.ContainsKey("WhatIf")) {
                 #create a dummy file name is using -Whatif
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Creating a dummy file for WhatIf purposes"
-                $filename = Join-Path -path $Path -ChildPath "whatif-PS7Preview.msi"
+                $filename = Join-Path -Path $Path -ChildPath "whatif-PS7Preview.msi"
             }
             else {
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Saving download to $Path"
@@ -491,7 +491,7 @@ Function Install-PowerShell {
             if ($PSBoundParameters.ContainsKey("WhatIf")) {
                 #create a dummy file name is using -Whatif
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Creating a dummy file for WhatIf purposes"
-                $filename = Join-Path -path $Path -ChildPath "whatif-ps7.msi"
+                $filename = Join-Path -Path $Path -ChildPath "whatif-ps7.msi"
             }
             else {
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Saving download to $Path "

--- a/functions/public.ps1
+++ b/functions/public.ps1
@@ -376,7 +376,7 @@ Function Get-PSReleaseAsset {
                 $assets
             }
             else {
-                Write-Warning "Get-PSReleaseAsset Failed to find any release assets using the specified critiria."
+                Write-Warning "Get-PSReleaseAsset Failed to find any release assets using the specified criteria."
             }
         } #Try
         catch {


### PR DESCRIPTION
* Fix casing issue (follow-up #23)
* Fix `critiria` typo not fixed in fa855f41918692dc9c722b6fcf6d25b4711f5da2
* Apply PSScriptAnalyzer [PSUseCorrectCasing](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCorrectCasing.md) fix
* Use correct case throughout